### PR TITLE
fix: runtime_container_engine_config - allow container to be restarte…

### DIFF
--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -5,6 +5,10 @@ locals {
 
   active_active = var.operational_mode == "active-active"
   disk          = var.operational_mode == "disk"
+
+  container_restart_policy = format("%s%s", var.container_restart_policy, var.container_restart_policy == "on-failure" ? format(":%d", var.container_restart_max_retries) : "")
+  container_restart        = var.container_allow_restart ? local.container_restart_policy : "no"
+
   env = merge(
     local.database_configuration,
     local.redis_configuration,
@@ -65,7 +69,7 @@ locals {
             "${var.metrics_endpoint_port_https}:9091"
           ] : []
         ])
-
+        restart = local.container_restart
         volumes = flatten([
           {
             type   = "bind"

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -189,6 +189,32 @@ variable "operational_mode" {
   }
 }
 
+variable "container_allow_restart" {
+  default     = false
+  type        = bool
+  description = "(Optional) Allow TFE containers to be automatically restarted."
+}
+
+variable "container_restart_policy" {
+  default     = "unless-stopped"
+  type        = string
+  description = "(Optional) Allow TFE containers to be automatically restarted."
+  validation {
+    condition = (
+      var.container_restart_policy == "on-failure" ||
+      var.container_restart_policy == "always" ||
+      var.container_restart_policy == "unless-stopped"
+    )
+    error_message = "Supported values for container_restart_policy are 'on-failure', 'always', and 'unless-stopped'."
+  }
+}
+
+variable "container_restart_max_retries" {
+  default     = 1
+  type        = number
+  description = "(Optional) Allow TFE containers to be automatically restarted x number of times."
+}
+
 variable "redis_host" {
   type        = string
   description = "The Redis server to connect to in the format HOST[:PORT] (e.g. redis.example.com or redis.example.com:). If only HOST is provided then the :PORT defaults to :6379 if no value is given. Required when TFE_OPERATIONAL_MODE is active-active."


### PR DESCRIPTION
…d - add restart modes and max number of restarts.

## Background

Please include a one or two sentence description of what you're changing and why.

Relates OR Closes #0000

## How has this been tested?

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
