### PR TITLE
fix: runtime_container_engine_config - https/http port cannot be null…

### DIFF
--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -5,6 +5,10 @@ locals {
 
   active_active = var.operational_mode == "active-active"
   disk          = var.operational_mode == "disk"
+
+  http_port = var.http_port != null ? var.http_port : "80"
+  https_port = var.https_port != null ? var.https_port : "443"
+
   env = merge(
     local.database_configuration,
     local.redis_configuration,
@@ -18,8 +22,8 @@ locals {
       no_proxy                      = var.no_proxy != null ? join(",", var.no_proxy) : null
       NO_PROXY                      = var.no_proxy != null ? join(",", var.no_proxy) : null
       TFE_HOSTNAME                  = var.hostname
-      TFE_HTTP_PORT                 = var.http_port
-      TFE_HTTPS_PORT                = var.https_port
+      TFE_HTTP_PORT                 = local.http_port
+      TFE_HTTPS_PORT                = local.https_port
       TFE_OPERATIONAL_MODE          = var.operational_mode
       TFE_ENCRYPTION_PASSWORD       = random_id.enc_password.hex
       TFE_DISK_CACHE_VOLUME_NAME    = "terraform-enterprise_terraform-enterprise-cache"
@@ -57,8 +61,8 @@ locals {
           "/var/log/terraform-enterprise",
         ]
         ports = flatten([
-          "80:${var.http_port}",
-          "443:${var.https_port}",
+          "80:${local.http_port}",
+          "443:${local.https_port}",
           local.active_active ? ["8201:8201"] : [],
           var.metrics_endpoint_enabled ? [
             "${var.metrics_endpoint_port_http}:9090",


### PR DESCRIPTION
… value. Breaks deployment.

## Background

Please include a one or two sentence description of what you're changing and why.

Relates OR Closes #0000

## How has this been tested?

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
