### PR TITLE
fix: tfe_init - support for self signed certs for internal services

### DIFF
--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
+  tfe_hostname = var.tfe_hostname != null ? var.tfe_hostname : "localhost"
 
   tls_bootstrap_path          = "/etc/tfe/ssl"
   tls_bootstrap_cert_pathname = "${local.tls_bootstrap_path}/cert.pem"
@@ -76,5 +77,7 @@ locals {
       registry_credential = base64encode("${var.registry_username}:${var.registry_password}")
 
       tfe_image = var.tfe_image
+      
+      tfe_hostname = local.tfe_hostname
   })
 }

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -72,6 +72,20 @@ chmod 0600 ${tls_bootstrap_key_pathname}
 %{ else ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapKey configuration" | tee -a $log_pathname
 %{ endif ~}
+
+%{ if key_secret_id == null && certificate_secret_id == null ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Generating Self-Signed TlsBootstrapCert/TlsBootstrapKey configuration" | tee -a $log_pathname
+mkdir -p $(dirname ${tls_bootstrap_key_pathname})
+cd $(dirname ${tls_bootstrap_key_pathname})
+%{ if ${tfe_hostname} != "localhost" ~}
+openssl req -x509 -nodes -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -subj "/CN=${hostname}/L=Internal"
+%{ else ~}
+local_hostname=$(ec2metadata --local-hostname)
+openssl req -x509 -nodes -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -subj "/CN=$local_hostname/L=Internal"
+%{ endif ~}
+
+cp cert.pem bundle.pem
+%{ endif ~}
 ca_certificate_directory="/dev/null"
 %{ if distribution == "rhel" ~}
 ca_certificate_directory=/usr/share/pki/ca-trust-source/anchors

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -134,3 +134,9 @@ variable "tfe_image" {
   type        = string
   description = "The registry path, image name, and image version (e.g. \"quay.io/hashicorp/terraform-enterprise:1234567\")"
 }
+
+variable "tfe_hostname" {
+  default     = null
+  type        = string
+  description = "Hostname where Terraform Enterprise is accessed (e.g. terraform.example.com). Used for generating TLS certificates."
+}


### PR DESCRIPTION
## Background

Please include a one or two sentence description of what you're changing and why.

Relates OR Closes #0000

## How has this been tested?

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
